### PR TITLE
Init Go module and add assets package

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,25 @@
+package assets
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+var basepath string
+
+func init() {
+	_, goFilename, _, _ := runtime.Caller(0)
+	basepath = filepath.Dir(filepath.Dir(goFilename))
+}
+
+// Path returns the absolute filepath of a file or directory relative to the
+// root of the dcrdex-assets main module.
+//
+// For example, to access the filepath of the site assets directory, call
+// Path("dexc/site").
+//
+// This function is only usable when built without -trimpath and on the host the
+// Go program was compiled on.
+func Path(asset string) string {
+	return filepath.Join(basepath, asset)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module decred.org/dcrdex-assets
+
+go 1.15


### PR DESCRIPTION
The assets package may be used to get the absolute filepath of any
file or directory relative root of the module.  This will be used by
the release builder to access the site contents for creating dexc
distributions.